### PR TITLE
PureNode has multiple output pins

### DIFF
--- a/Source/CommonValidators/EditorValidator_PoreNode.cpp
+++ b/Source/CommonValidators/EditorValidator_PoreNode.cpp
@@ -1,0 +1,54 @@
+#include "EditorValidator_PureNode.h"
+
+#include "Engine/Blueprint.h"
+#include "Misc/DataValidation.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "EdGraphSchema_K2.h"
+#include "K2Node.h"
+
+
+bool UEditorValidator_PureNode::CanValidateAsset_Implementation(const FAssetData& InAssetData, UObject* InObject, FDataValidationContext& InContext) const
+{
+	return InObject && InObject->IsA<UBlueprint>();
+}
+
+EDataValidationResult UEditorValidator_PureNode::ValidateLoadedAsset_Implementation(const FAssetData& InAssetData, UObject* InAsset, FDataValidationContext& Context)
+{
+	UBlueprint* Blueprint = Cast<UBlueprint>(InAsset);
+	if (!Blueprint) return EDataValidationResult::NotValidated;
+
+	for (UEdGraph* Graph : Blueprint->UbergraphPages)
+	{
+		for (UEdGraphNode* Node : Graph->Nodes)
+		{
+			UK2Node* PureNode = Cast<UK2Node>(Node);
+			if (PureNode && PureNode->IsNodePure())
+			{
+				if (IsMultiPinPureNode(PureNode))
+				{
+					FText output = FText::Join(FText::FromString(" "), PureNode->GetNodeTitle(ENodeTitleType::Type::MenuTitle), FText::FromString(TEXT("MultiPin Pure Nodes actually get called for each connected pin output.")));
+					Context.AddError(output);
+					return EDataValidationResult::Invalid;
+				}
+			}
+		}
+	}
+
+	return EDataValidationResult::Valid;
+}
+
+bool UEditorValidator_PureNode::IsMultiPinPureNode(UK2Node* PureNode)
+{
+	int PinConnectionCount = 0;
+	for (UEdGraphPin* Pin : PureNode->Pins)
+	{
+		//if we're an output pin and we have a connection in the graph - this counts.
+		if (Pin->Direction == EGPD_Output && Pin->LinkedTo.Num() > 0)
+		{
+			PinConnectionCount++;
+		}
+	}
+	
+	return PinConnectionCount > 1;
+}

--- a/Source/CommonValidators/EditorValidator_PureNode.h
+++ b/Source/CommonValidators/EditorValidator_PureNode.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "EditorValidatorBase.h"
+#include "EditorValidator_PureNode.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class COMMONVALIDATORS_API UEditorValidator_PureNode : public UEditorValidatorBase
+{
+	GENERATED_BODY()
+
+	virtual bool CanValidateAsset_Implementation(const FAssetData& InAssetData, UObject* InObject, FDataValidationContext& InContext) const override;
+	virtual EDataValidationResult ValidateLoadedAsset_Implementation(const FAssetData& InAssetData, UObject* InAsset, FDataValidationContext& Context) override;
+
+	bool IsMultiPinPureNode(class UK2Node* PureNode);
+	
+};


### PR DESCRIPTION
This is a validator that will look at PureNodes and detected if they have multiple output pins. 
Each output pin that is used for a PureNode results in the whole of the PureNode being executed. 