### PR TITLE
PureNode validator ignores Break Struct

### DIFF
--- a/Source/CommonValidators/EditorValidator_PureNode.cpp
+++ b/Source/CommonValidators/EditorValidator_PureNode.cpp
@@ -5,6 +5,7 @@
 #include "EdGraph/EdGraph.h"
 #include "EdGraph/EdGraphNode.h"
 #include "EdGraphSchema_K2.h"
+#include "K2Node_BreakStruct.h"
 #include "K2Node.h"
 
 
@@ -25,7 +26,7 @@ EDataValidationResult UEditorValidator_PureNode::ValidateLoadedAsset_Implementat
 			UK2Node* PureNode = Cast<UK2Node>(Node);
 			if (PureNode && PureNode->IsNodePure())
 			{
-				if (IsMultiPinPureNode(PureNode))
+				if (IsMultiPinPureNode(PureNode) && !IsWhitelistedPureNode(PureNode))
 				{
 					FText output = FText::Join(FText::FromString(" "), PureNode->GetNodeTitle(ENodeTitleType::Type::MenuTitle), FText::FromString(TEXT("MultiPin Pure Nodes actually get called for each connected pin output.")));
 					Context.AddError(output);
@@ -51,4 +52,21 @@ bool UEditorValidator_PureNode::IsMultiPinPureNode(UK2Node* PureNode)
 	}
 	
 	return PinConnectionCount > 1;
+}
+
+bool UEditorValidator_PureNode::IsWhitelistedPureNode(UK2Node* PureNode)
+{
+	static const TArray<UClass*> WhitelistedTypes = {
+		UK2Node_BreakStruct::StaticClass()
+		// Add here any other classes that should be whitelisted
+	};
+
+	for (UClass* WhitelistedClass : WhitelistedTypes)
+	{
+		if (PureNode->IsA(WhitelistedClass))
+		{
+			return true;
+		}
+	}
+	return false;
 }

--- a/Source/CommonValidators/EditorValidator_PureNode.h
+++ b/Source/CommonValidators/EditorValidator_PureNode.h
@@ -16,5 +16,8 @@ class COMMONVALIDATORS_API UEditorValidator_PureNode : public UEditorValidatorBa
 	virtual EDataValidationResult ValidateLoadedAsset_Implementation(const FAssetData& InAssetData, UObject* InAsset, FDataValidationContext& Context) override;
 
 	bool IsMultiPinPureNode(class UK2Node* PureNode);
-	
+
+	// Indicates if the given pure node is whitelisted and should not be flagged as a multi-pin pure node.
+	bool IsWhitelistedPureNode(class UK2Node* PureNode);
+
 };


### PR DESCRIPTION
Modified PureNode validator to add a whitelist of nodes to skip, currently only containing Break Struct.

Fixes [Issue#6](https://github.com/Flassari/CommonValidators/issues/6)