### PR TITLE
Proper pure node validator

### DIFF
--- a/Source/CommonValidators/CommonValidators.Build.cs
+++ b/Source/CommonValidators/CommonValidators.Build.cs
@@ -12,6 +12,7 @@ public class CommonValidators : ModuleRules
 			"Engine",
 			"DataValidation",
 			"BlueprintGraph",
+			"DeveloperSettings",
 			"Kismet",
 			"UnrealEd"
 		});

--- a/Source/CommonValidators/CommonValidatorsDeveloperSettings.cpp
+++ b/Source/CommonValidators/CommonValidatorsDeveloperSettings.cpp
@@ -1,0 +1,1 @@
+#include "CommonValidatorsDeveloperSettings.h"

--- a/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
+++ b/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Engine/DeveloperSettings.h"
+
+#include "CommonValidatorsDeveloperSettings.generated.h"
+
+UCLASS(config = Editor, defaultconfig, meta = (DisplayName = "Common Validators"))
+class COMMONVALIDATORS_API UCommonValidatorsDeveloperSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+
+public:
+	// If true, we will validate for empty tick nodes.
+	UPROPERTY(Config, EditAnywhere)
+	bool bEnableEmptyTickNodeValidator = true;
+	
+	//If true, we throw an error, otherwise a warning!
+	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableEmptyTickNodeValidator == true"))
+	bool bErrorOnEmptyTickNodes = true;
+	
+	// if true, we will validate for pure nodes being executed multiple times
+	UPROPERTY(Config, EditAnywhere)
+	bool bEnablePureNodeMultiExecValidator = true;
+	
+	//If true, we throw an error, otherwise a warning!
+	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnablePureNodeMultiExecValidator == true"))
+	bool bErrorOnPureNodeMultiExec = true;
+	
+	// If true, we will validate for blocking loads in blueprints
+	UPROPERTY(Config, EditAnywhere)
+	bool bEnableBlockingLoadValidator = true;
+	
+	//If true, we throw an error, otherwise a warning!
+	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableBlockingLoadValidator == true"))
+	bool bErrorBlockingLoad = true;
+};

--- a/Source/CommonValidators/EditorValidator_PureNode.cpp
+++ b/Source/CommonValidators/EditorValidator_PureNode.cpp
@@ -9,107 +9,235 @@
 #include "K2Node_BreakStruct.h"
 #include "K2Node_Variable.h"
 #include "CommonValidatorsStatics.h"
-
+#include "CommonValidatorsDeveloperSettings.h"
 #include "K2Node.h"
 
-
-bool UEditorValidator_PureNode::CanValidateAsset_Implementation(const FAssetData& InAssetData, UObject* InObject, FDataValidationContext& InContext) const
+namespace UE::Internal::PureNodeValidatorHelpers
 {
-	return InObject && InObject->IsA<UBlueprint>();
+    // Finds every event/function entry (no incoming exec) in the graph.
+    static void CollectExecEntries(UEdGraph* Graph, TSet<UEdGraphNode*>& OutEntries)
+    {
+        for (UEdGraphNode* Node : Graph->Nodes)
+        {
+            if (Node->FindPin(UEdGraphSchema_K2::PN_Execute, EGPD_Input) == nullptr)
+            {
+                OutEntries.Add(Node);
+            }
+        }
+    }
+
+    // Marks all nodes reachable via exec pins from those entries.
+    static void CollectReachableExecNodes(UEdGraph* Graph, TSet<UEdGraphNode*>& OutReachable)
+    {
+        TSet<UEdGraphNode*> Visited;
+        TArray<UEdGraphNode*> Queue;
+
+        CollectExecEntries(Graph, Visited);
+        for (UEdGraphNode* Entry : Visited)
+        {
+            Queue.Add(Entry);
+        }
+
+        while (Queue.Num() > 0)
+        {
+            UEdGraphNode* Current = Queue.Pop();
+            OutReachable.Add(Current);
+
+            for (UEdGraphPin* Pin : Current->Pins)
+            {
+                if (Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec && Pin->Direction == EGPD_Output)
+                {
+                    for (UEdGraphPin* Link : Pin->LinkedTo)
+                    {
+                        UEdGraphNode* Next = Link->GetOwningNode();
+                        if (!Visited.Contains(Next))
+                        {
+                            Visited.Add(Next);
+                            Queue.Add(Next);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Walks the data‑pin graph until the first connected exec‑input is found.
+    static UEdGraphNode* FindFirstImpureSink(UEdGraphNode* StartNode)
+    {
+        TSet<UEdGraphNode*> Visited;
+        TArray<UEdGraphNode*> Queue = { StartNode };
+
+        while (Queue.Num() > 0)
+        {
+            UEdGraphNode* Current = Queue.Pop();
+            if (Visited.Contains(Current))
+            {
+                continue;
+            }
+            Visited.Add(Current);
+
+            if (UEdGraphPin* ExecIn = Current->FindPin(UEdGraphSchema_K2::PN_Execute, EGPD_Input))
+            {
+                if (ExecIn->LinkedTo.Num() > 0)
+                {
+                    return Current;
+                }
+            }
+
+            for (UEdGraphPin* Pin : Current->Pins)
+            {
+                if (Pin->Direction == EGPD_Output && Pin->PinType.PinCategory != UEdGraphSchema_K2::PC_Exec)
+                {
+                    for (UEdGraphPin* Link : Pin->LinkedTo)
+                    {
+                        Queue.Add(Link->GetOwningNode());
+                    }
+                    for (UEdGraphPin* Sub : Pin->SubPins)
+                    {
+                        for (UEdGraphPin* Link : Sub->LinkedTo)
+                        {
+                            Queue.Add(Link->GetOwningNode());
+                        }
+                    }
+                }
+            }
+        }
+
+        return nullptr;
+    }
+
+    bool WillPureNodeFireMultipleTimes(UK2Node* PureFunctionNode, UEdGraph* Graph)
+    {
+        TSet<UEdGraphNode*> Reachable;
+        CollectReachableExecNodes(Graph, Reachable);
+
+        TSet<UEdGraphNode*> DataConsumers;
+        for (UEdGraphPin* Pin : PureFunctionNode->Pins)
+        {
+            if (Pin->Direction != EGPD_Output || Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
+            {
+                continue;
+            }
+
+            for (UEdGraphPin* Link : Pin->LinkedTo)
+            {
+                DataConsumers.Add(Link->GetOwningNode());
+            }
+            for (UEdGraphPin* Sub : Pin->SubPins)
+            {
+                for (UEdGraphPin* Link : Sub->LinkedTo)
+                {
+                    DataConsumers.Add(Link->GetOwningNode());
+                }
+            }
+        }
+
+        TSet<UEdGraphNode*> ExecSinks;
+        for (UEdGraphNode* Consumer : DataConsumers)
+        {
+            UEdGraphNode* Sink = FindFirstImpureSink(Consumer);
+            if (Sink != nullptr && Reachable.Contains(Sink))
+            {
+                ExecSinks.Add(Sink);
+                if (ExecSinks.Num() > 1)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+} // namespace UE::Internal::PureNodeValidatorHelpers
+
+
+bool UEditorValidator_PureNode::CanValidateAsset_Implementation(
+    const FAssetData& InAssetData,
+    UObject* InObject,
+    FDataValidationContext& InContext) const
+{
+	bool bIsValidatorEnabled = GetDefault<UCommonValidatorsDeveloperSettings>()->bEnablePureNodeMultiExecValidator;
+    return bIsValidatorEnabled && (InObject != nullptr) && InObject->IsA<UBlueprint>();
 }
+
 
 EDataValidationResult UEditorValidator_PureNode::ValidateLoadedAsset_Implementation(const FAssetData& InAssetData, UObject* InAsset, FDataValidationContext& Context)
 {
-	UBlueprint* Blueprint = Cast<UBlueprint>(InAsset);
-	if (!Blueprint) return EDataValidationResult::NotValidated;
+    UBlueprint* Blueprint = Cast<UBlueprint>(InAsset);
+    if (Blueprint == nullptr)
+    {
+        return EDataValidationResult::NotValidated;
+    }
+	bool bFoundBadNode = false;
+	bool bShouldError = GetDefault<UCommonValidatorsDeveloperSettings>()->bErrorOnPureNodeMultiExec;
 
-	bool bHasMultiPinPureNode = false;
+    for (UEdGraph* Graph : Blueprint->UbergraphPages)
+    {
+        for (UEdGraphNode* Node : Graph->Nodes)
+        {
+            if (Node->IsA<UK2Node_BreakStruct>() || Node->IsA<UK2Node_Variable>())
+            {
+                continue;
+            }
 
-	for (UEdGraph* Graph : Blueprint->UbergraphPages)
-	{
-		for (UEdGraphNode* Node : Graph->Nodes)
-		{
-			UK2Node* PureNode = Cast<UK2Node>(Node);
-			// If is a "UK2Node_BreakStruct" continue, these can't take 'show exec pins' anyhow
-			if (Node->IsA(UK2Node_BreakStruct::StaticClass())) continue;
-			// Questionable, but we don't want to show warnings for variable nodes, although they can take show exec pins and might have 'split pins'
-			if (Node->IsA(UK2Node_Variable::StaticClass())) continue;
-			// We should skip break/make nodes, for example, GameplayCueParameters.
-			// This is pure but its native break/make. So let's skip them, they are safe --KaosSpectrum
-			if (UK2Node_CallFunction* CallFunction = Cast<UK2Node_CallFunction>(Node))
-			{
-				UFunction* TargetFunc = CallFunction->GetTargetFunction();
-				if (TargetFunc && (TargetFunc->HasMetaData(TEXT("NativeBreakFunc")) || TargetFunc->HasMetaData(TEXT("NativeMakeFunc"))))
-				{
-					continue;
-				}
-			}
-			if (PureNode && PureNode->IsNodePure())
-			{
-				if (IsMultiPinPureNode(PureNode) && !IsWhitelistedPureNode(PureNode))
-				{
-					FText output = FText::Join(FText::FromString(" "), PureNode->GetNodeTitle(ENodeTitleType::Type::MenuTitle), FText::FromString(" - "), FText::FromString(TEXT("MultiPin Pure Nodes actually get called for each connected pin output.")));
+            UK2Node_CallFunction* CallNode = Cast<UK2Node_CallFunction>(Node);
+            if (CallNode == nullptr)
+            {
+                continue;
+            }
 
-					PureNode->ErrorMsg = output.ToString();
-					PureNode->ErrorType = EMessageSeverity::Warning;
-					PureNode->bHasCompilerMessage = true;
-					
-					// Create tokenized message with action using UCommonValidatorsStatics::OpenBlueprintAndFocusNode
-					TSharedRef<FTokenizedMessage> TokenizedMessage = FTokenizedMessage::Create(EMessageSeverity::Warning, output);
-					TokenizedMessage->AddToken(FActionToken::Create(
-						FText::FromString(TEXT("Open Blueprint and Focus Node")),
-						FText::FromString(TEXT("Open Blueprint and Focus Node")),
-						FOnActionTokenExecuted::CreateLambda([Blueprint, Graph, PureNode]()
-							{
-								UCommonValidatorsStatics::OpenBlueprintAndFocusNode(Blueprint, Graph, PureNode);
-							}),
-						false
-					));
+            if (UFunction* TargetFunc = CallNode->GetTargetFunction())
+            {
+                if (TargetFunc->HasMetaData(TEXT("NativeBreakFunc")) ||
+                    TargetFunc->HasMetaData(TEXT("NativeMakeFunc")))
+                {
+                    continue;
+                }
+            }
 
-					Context.AddMessage(TokenizedMessage);
+            if (!CallNode->IsNodePure())
+            {
+                continue;
+            }
 
-					bHasMultiPinPureNode = true;
-					Graph->NotifyNodeChanged(Node);
-				}
-			}
-		}
-	}
-	if (bHasMultiPinPureNode)
+            if (UE::Internal::PureNodeValidatorHelpers::WillPureNodeFireMultipleTimes(CallNode, Graph))
+            {
+                const FText Title = CallNode->GetNodeTitle(ENodeTitleType::MenuTitle);
+                const FText Message = FText::Format(
+                    NSLOCTEXT("PureNodeValidator", "MultiCallWarning",
+                              "{0} will execute more than once. Convert to exec or avoid using across multiple exec nodes."),
+                    Title
+                );
+                CallNode->ErrorMsg            = Message.ToString();
+                CallNode->ErrorType           = bShouldError ? EMessageSeverity::Error : EMessageSeverity::Warning;
+                CallNode->bHasCompilerMessage = true;
+
+                TSharedRef<FTokenizedMessage> TokenMessage =
+                    FTokenizedMessage::Create(EMessageSeverity::Warning, Message);
+
+                TokenMessage->AddToken(
+                    FActionToken::Create(
+                        NSLOCTEXT("PureNodeValidator", "OpenNode", "Focus Node"),
+                        NSLOCTEXT("PureNodeValidator", "OpenNodeTooltip", "Open this node in the Blueprint Editor"),
+                        FOnActionTokenExecuted::CreateLambda([Blueprint, Graph, CallNode]()
+                        {
+                            UCommonValidatorsStatics::OpenBlueprintAndFocusNode(Blueprint, Graph, CallNode);
+                        }),
+                        /*bEnabled=*/false
+                    )
+                );
+
+                Context.AddMessage(TokenMessage);
+                Graph->NotifyNodeChanged(Node);
+				bFoundBadNode = true;
+            }
+        }
+    }
+
+	if (bShouldError && bFoundBadNode)
 	{
 		return EDataValidationResult::Invalid;
 	}
-
-	return EDataValidationResult::Valid;
-}
-
-bool UEditorValidator_PureNode::IsMultiPinPureNode(UK2Node* PureNode)
-{
-	int PinConnectionCount = 0;
-	for (UEdGraphPin* Pin : PureNode->Pins)
-	{
-		// If we're an output pin and we have a connection in the graph - this counts.
-		if (Pin->Direction == EGPD_Output && Pin->LinkedTo.Num() > 0)
-		{
-			PinConnectionCount++;
-		}
-	}
 	
-	return PinConnectionCount > 1;
-}
-
-bool UEditorValidator_PureNode::IsWhitelistedPureNode(UK2Node* PureNode)
-{
-	static const TArray<UClass*> WhitelistedTypes = {
-		UK2Node_BreakStruct::StaticClass()
-		// Add here any other classes that should be whitelisted
-	};
-
-	for (UClass* WhitelistedClass : WhitelistedTypes)
-	{
-		if (PureNode->IsA(WhitelistedClass))
-		{
-			return true;
-		}
-	}
-	return false;
+    return EDataValidationResult::Valid;
 }

--- a/Source/CommonValidators/EditorValidator_PureNode.cpp
+++ b/Source/CommonValidators/EditorValidator_PureNode.cpp
@@ -14,6 +14,58 @@
 
 namespace UE::Internal::PureNodeValidatorHelpers
 {
+	bool IsHarmlessPureNode(UK2Node_CallFunction* CallNode)
+	{
+		if (!CallNode) return false;
+
+		UFunction* Func = CallNode->GetTargetFunction();
+		if (!Func)
+		{
+			return false;
+		}
+
+		if (Func->HasMetaData(TEXT("NativeBreakFunc")) || Func->HasMetaData(TEXT("NativeMakeFunc")))
+		{
+			return true;
+		}
+
+		UClass* OwnerClass = Func->GetOuterUClass();
+		if (!OwnerClass)
+		{
+			return false;
+		}
+		
+		const FString OwnerName = OwnerClass->GetName();
+
+		if (OwnerName.Contains(TEXT("KismetMathLibrary")) ||
+			OwnerName.Contains(TEXT("KismetSystemLibrary")) ||
+			OwnerName.Contains(TEXT("KismetTextLibrary")) ||
+			OwnerName.Contains(TEXT("KismetStringTableLibrary")) ||
+			OwnerName.Contains(TEXT("KismetRenderingLibrary")) ||
+			OwnerName.Contains(TEXT("KismetMaterialLibrary")) ||
+			OwnerName.Contains(TEXT("KismetInternationalizationLibrary")) ||
+			OwnerName.Contains(TEXT("KismetInputLibrary")) ||
+			OwnerName.Contains(TEXT("KismetGuidLibrary")) ||
+			OwnerName.Contains(TEXT("KismetArrayLibrary")) ||
+			OwnerName.Contains(TEXT("GameplayStatics")) ||
+			OwnerName.Contains(TEXT("DataTableFunctionLibrary")) ||
+			OwnerName.Contains(TEXT("BlueprintSetLibrary")) ||
+			OwnerName.Contains(TEXT("BlueprintPlatformLibrary")) ||
+			OwnerName.Contains(TEXT("BlueprintPathsLibrary")) ||
+			OwnerName.Contains(TEXT("BlueprintMapLibrary")) ||
+			OwnerName.Contains(TEXT("BlueprintInstancedStructLibrary")) ||
+			OwnerName.Contains(TEXT("KismetNodeHelperLibrary")))
+		{
+			return true;
+		}
+
+		//TODO: Allow users to expand the list above? --KaosSpectrum
+		//Maybe find a better way (though i can't think of one...)
+		
+
+		return false;
+	}
+	
     // Finds every event/function entry (no incoming exec) in the graph.
     static void CollectExecEntries(UEdGraph* Graph, TSet<UEdGraphNode*>& OutEntries)
     {
@@ -195,7 +247,7 @@ EDataValidationResult UEditorValidator_PureNode::ValidateLoadedAsset_Implementat
                 }
             }
 
-            if (!CallNode->IsNodePure())
+            if (!CallNode->IsNodePure() || UE::Internal::PureNodeValidatorHelpers::IsHarmlessPureNode(CallNode))
             {
                 continue;
             }

--- a/Source/CommonValidators/EditorValidator_PureNode.h
+++ b/Source/CommonValidators/EditorValidator_PureNode.h
@@ -5,7 +5,7 @@
 #include "EditorValidator_PureNode.generated.h"
 
 /**
- * 
+ *
  */
 UCLASS()
 class COMMONVALIDATORS_API UEditorValidator_PureNode : public UEditorValidatorBase
@@ -14,10 +14,4 @@ class COMMONVALIDATORS_API UEditorValidator_PureNode : public UEditorValidatorBa
 
 	virtual bool CanValidateAsset_Implementation(const FAssetData& InAssetData, UObject* InObject, FDataValidationContext& InContext) const override;
 	virtual EDataValidationResult ValidateLoadedAsset_Implementation(const FAssetData& InAssetData, UObject* InAsset, FDataValidationContext& Context) override;
-
-	bool IsMultiPinPureNode(class UK2Node* PureNode);
-
-	// Indicates if the given pure node is whitelisted and should not be flagged as a multi-pin pure node.
-	bool IsWhitelistedPureNode(class UK2Node* PureNode);
-
 };


### PR DESCRIPTION
I reworked the pure node validator to be proper validator.

Test cases: 
<img width="1319" height="430" alt="image" src="https://github.com/user-attachments/assets/56934cca-af48-45de-b3cf-205225214daa" />
This is fine, it only executes the pure node once.

<img width="1276" height="449" alt="image" src="https://github.com/user-attachments/assets/99ed712d-9870-48e1-a1cd-c5d0ab1c1912" />
Not fine, will execute the pure node 3 times.

<img width="1174" height="379" alt="image" src="https://github.com/user-attachments/assets/6a4e7280-e9b6-46d4-9b75-9f30b34b0297" />
Fine will only execute the pure node once.

<img width="1150" height="446" alt="image" src="https://github.com/user-attachments/assets/49a13f9c-e4df-49f1-90dc-35e8bd698538" />
Not fine, will execute the pure node twice.

<img width="1198" height="349" alt="image" src="https://github.com/user-attachments/assets/d6d7e836-8386-49bb-81ea-e2691099bfc5" />
Not fine, could execute twice, but we cant determine the result of a branch at compile time.

Basically it doesnt blindly check the amount of connection pins, thats invalid. A pure node is fine to do that, instead it checks down stream execution nodes.
In my test in the above screenshots i validated it doesnt throw any issues unless the node WILL actually be called twice (or possible twice, we cant detect too well at branches..... etc)

We can't detect where things can be changed dynamically at one time, it may only be called once due that branch, but i am working on a way to check the graph links to remove this limitation as a branch can only go one way which means it will only ever be called once unless the pure node is connected to it.

Up for any ideas/suggesstions to improve it.

Also added developer settings so people can turn on/off validators they dont need/want or downgrade them.

