### PR TITLE
WIP: Heavy Reference Validator

### DIFF
--- a/CommonValidators.uplugin
+++ b/CommonValidators.uplugin
@@ -25,6 +25,10 @@
 		{
 			"Name": "DataValidation",
 			"Enabled": true
+		},
+		{
+			"Name": "AssetManagerEditor",
+			"Enabled":  true
 		}
 	]
 }

--- a/Source/CommonValidators/CommonValidators.Build.cs
+++ b/Source/CommonValidators/CommonValidators.Build.cs
@@ -14,7 +14,8 @@ public class CommonValidators : ModuleRules
 			"BlueprintGraph",
 			"DeveloperSettings",
 			"Kismet",
-			"UnrealEd"
+			"UnrealEd",
+			"AssetManagerEditor"
 		});
 	}
 }

--- a/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
+++ b/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
@@ -4,6 +4,19 @@
 
 #include "CommonValidatorsDeveloperSettings.generated.h"
 
+USTRUCT(BlueprintType)
+struct FCommonValidatorClassArray
+{
+	GENERATED_BODY()
+	
+	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	TArray<TSubclassOf<UObject>> ClassList;
+
+	// Should this rule propagate to discovered children?
+	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	bool AllowPropagationToChildren = true;
+};
+
 UCLASS(config = Editor, defaultconfig, meta = (DisplayName = "Common Validators"))
 class COMMONVALIDATORS_API UCommonValidatorsDeveloperSettings : public UDeveloperSettings
 {
@@ -33,4 +46,24 @@ public:
 	//If true, we throw an error, otherwise a warning!
 	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableBlockingLoadValidator == true"))
 	bool bErrorBlockingLoad = true;
+
+	// If true, we will validate for references above the set value in blueprints
+	UPROPERTY(Config, EditAnywhere)
+	bool bEnableHeavyReferenceValidator = true;
+
+	// If the total size on disk is above this, we consider the asset heavy
+	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	int MaximumAllowedReferenceSizeKiloBytes = 128;
+
+	//If true, we throw an error, otherwise a warning!
+	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	bool bErrorHeavyReference = false;
+
+	// Classes in this list, and their children, are ignored by heavy reference validator
+	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	TArray<TSubclassOf<UObject>> HeavyValidatorClassAndChildIgnoreList = {UAnimBlueprint::StaticClass()};
+
+	// Classes in this list, and only classes in this list, are ignored by heavy reference validator
+	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	TMap<TSubclassOf<UObject>, FCommonValidatorClassArray> HeavyValidatorClassSpecificClassIgnoreList;
 };

--- a/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
+++ b/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
@@ -9,11 +9,11 @@ struct FCommonValidatorClassArray
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Common Validators")
 	TArray<TSubclassOf<UObject>> ClassList;
 
 	// Should this rule propagate to discovered children?
-	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Common Validators")
 	bool AllowPropagationToChildren = true;
 };
 
@@ -24,46 +24,51 @@ class COMMONVALIDATORS_API UCommonValidatorsDeveloperSettings : public UDevelope
 
 public:
 	// If true, we will validate for empty tick nodes.
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators")
 	bool bEnableEmptyTickNodeValidator = true;
 	
 	//If true, we throw an error, otherwise a warning!
-	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableEmptyTickNodeValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableEmptyTickNodeValidator == true"))
 	bool bErrorOnEmptyTickNodes = true;
 	
 	// if true, we will validate for pure nodes being executed multiple times
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators")
 	bool bEnablePureNodeMultiExecValidator = true;
 	
 	//If true, we throw an error, otherwise a warning!
-	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnablePureNodeMultiExecValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnablePureNodeMultiExecValidator == true"))
 	bool bErrorOnPureNodeMultiExec = true;
 	
 	// If true, we will validate for blocking loads in blueprints
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators")
 	bool bEnableBlockingLoadValidator = true;
 	
 	//If true, we throw an error, otherwise a warning!
-	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableBlockingLoadValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableBlockingLoadValidator == true"))
 	bool bErrorBlockingLoad = true;
 
 	// If true, we will validate for references above the set value in blueprints
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators")
 	bool bEnableHeavyReferenceValidator = true;
 
 	// If the total size on disk is above this, we consider the asset heavy
-	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
-	int MaximumAllowedReferenceSizeKiloBytes = 128;
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	int MaximumAllowedReferenceSizeKiloBytes = 20480;
+
+	// Whether an inability to gather the size of a child asset is an warning
+	// This will prevent further context messages in most cases
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	bool bWarnOnUnsizableChildren = false;
 
 	//If true, we throw an error, otherwise a warning!
-	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
 	bool bErrorHeavyReference = false;
 
 	// Classes in this list, and their children, are ignored by heavy reference validator
-	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
 	TArray<TSubclassOf<UObject>> HeavyValidatorClassAndChildIgnoreList = {UAnimBlueprint::StaticClass()};
 
 	// Classes in this list, and only classes in this list, are ignored by heavy reference validator
-	UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
 	TMap<TSubclassOf<UObject>, FCommonValidatorClassArray> HeavyValidatorClassSpecificClassIgnoreList;
 };

--- a/Source/CommonValidators/CommonValidatorsStatics.cpp
+++ b/Source/CommonValidators/CommonValidatorsStatics.cpp
@@ -3,14 +3,20 @@
 #include "CommonValidatorsStatics.h"
 
 // Unreal
-#include "BlueprintEditorModule.h"
-#include "ScopedTransaction.h"
+#include "AssetManagerEditor/Public/AssetManagerEditorModule.h"
 #include "AssetRegistry/AssetDataToken.h"
+#include "BlueprintEditorModule.h"
 #include "EdGraph/EdGraph.h"
 #include "EdGraph/EdGraphNode.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "ScopedTransaction.h"
 #include "Subsystems/AssetEditorSubsystem.h"
 #include "Toolkits/AssetEditorToolkit.h"
+
+// Project
+
+// Local
+
 
 void UCommonValidatorsStatics::OpenBlueprint(UBlueprint* Blueprint)
 {
@@ -122,8 +128,6 @@ bool UCommonValidatorsStatics::IsAssetAChildOf(const FAssetData& AnyAssetReferen
 			const UObject* GeneratedClassCDO = IsValid(Blueprint->GeneratedClass) ? Blueprint->GeneratedClass->GetDefaultObject() : nullptr;
 			return IsObjectAChildOf(GeneratedClassCDO, ObjectClass);
 		}
-		
-		//null* const AsType = Cast<null>(GeneratedClassCDO);
 	}
 
 	return false;
@@ -143,4 +147,24 @@ TSharedRef<FTokenizedMessage> UCommonValidatorsStatics::CreateLinkedMessage(cons
 	}
 
 	return TokenizedMessage;
+}
+
+FAssetIdentifier UCommonValidatorsStatics::GetAssetIdentifierFromAssetData(const FAssetData& AssetData)
+{
+	// In the some MSVCs, RVO appears to only occur on the first instantiated return if the branches return
+	// In the other path, non-RVO is used
+	FAssetIdentifier ReturnIdentifier{};
+
+	FPrimaryAssetId PrimaryAssetId = IAssetManagerEditorModule::ExtractPrimaryAssetIdFromFakeAssetData(AssetData);
+
+	if (PrimaryAssetId.IsValid())
+	{
+		ReturnIdentifier = PrimaryAssetId;
+	}
+	else
+	{
+		ReturnIdentifier = AssetData.PackageName;
+	}
+
+	return ReturnIdentifier;
 }

--- a/Source/CommonValidators/CommonValidatorsStatics.cpp
+++ b/Source/CommonValidators/CommonValidatorsStatics.cpp
@@ -1,14 +1,28 @@
-#include "CommonValidatorsStatics.h"
-#include "Kismet2/BlueprintEditorUtils.h"
-#include "Toolkits/AssetEditorToolkit.h"
-#include "Kismet2/KismetEditorUtilities.h"
-#include "BlueprintEditorModule.h"
-#include "Subsystems/AssetEditorSubsystem.h"
-#include "IAssetTools.h"
 
+// Translation Unit
+#include "CommonValidatorsStatics.h"
+
+// Unreal
+#include "BlueprintEditorModule.h"
+#include "ScopedTransaction.h"
+#include "AssetRegistry/AssetDataToken.h"
 #include "EdGraph/EdGraph.h"
 #include "EdGraph/EdGraphNode.h"
-#include "ScopedTransaction.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Subsystems/AssetEditorSubsystem.h"
+#include "Toolkits/AssetEditorToolkit.h"
+
+void UCommonValidatorsStatics::OpenBlueprint(UBlueprint* Blueprint)
+{
+	if (!Blueprint)
+	{
+		return;
+	}
+	
+	// Open the Blueprint editor (or bring it to front)
+	UAssetEditorSubsystem* AssetEditorSubsystem = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>();
+	AssetEditorSubsystem->OpenEditorForAsset(Blueprint);
+}
 
 void UCommonValidatorsStatics::OpenBlueprintAndFocusNode(UBlueprint* Blueprint, UEdGraph* Graph, UEdGraphNode* Node)
 {
@@ -51,4 +65,82 @@ void UCommonValidatorsStatics::DeleteNodeFromBlueprint(UBlueprint* Blueprint, UE
 
     // Mark Blueprint as structurally modified (will trigger recompilation)
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+}
+
+bool UCommonValidatorsStatics::IsObjectAChildOf(const UObject* const AnyAssetReference, const TSubclassOf<UObject> ObjectClass)
+{
+	if (!IsValid(AnyAssetReference))
+	{
+		return false;
+	}
+
+	// Blueprint assets derive from UBlueprint first, so IsA won't work directly
+	if (AnyAssetReference->IsA(UBlueprint::StaticClass()))
+	{
+		// This asset may need converted to first native class unless ObjectClass is also a BP
+		const UBlueprint* const Blueprint = Cast<UBlueprint>(AnyAssetReference);
+		if (!IsValid(Blueprint))
+		{
+			return false;
+		}
+		
+		const UClass* const ParentClass = FBlueprintEditorUtils::FindFirstNativeClass(Blueprint->ParentClass);
+		if (ParentClass->IsChildOf(ObjectClass))
+		{
+			return true;
+		}
+	}
+
+	// Comparing actual classes
+	// For non-BPs, this is correct.
+	// For BPs, this works to catch ObjectClass being a child of UBlueprint, such as UAnimBlueprint.
+	return AnyAssetReference->IsA(ObjectClass);
+}
+
+bool UCommonValidatorsStatics::IsAssetAChildOf(const FAssetData& AnyAssetReference, const TSubclassOf<UObject> ObjectClass)
+{
+	// We can do a compare natively for AssetData, but if it returns Blueprint, then we have more work to do
+	const UClass* const AssetClass = AnyAssetReference.GetClass();
+	if (!IsValid(AssetClass))
+	{
+		return false;
+	}
+
+	// Early out for native classes
+	if (AssetClass->IsChildOf(ObjectClass))
+	{
+		return true;
+	}
+
+	if (AssetClass->IsChildOf(UBlueprint::StaticClass()))
+	{
+		// Get AssetClass CDO
+		const UObject* const LoadedAsset = AnyAssetReference.GetAsset();
+		const UBlueprint* const Blueprint = Cast<UBlueprint>(LoadedAsset);
+		if (IsValid(Blueprint))
+		{
+			const UObject* GeneratedClassCDO = IsValid(Blueprint->GeneratedClass) ? Blueprint->GeneratedClass->GetDefaultObject() : nullptr;
+			return IsObjectAChildOf(GeneratedClassCDO, ObjectClass);
+		}
+		
+		//null* const AsType = Cast<null>(GeneratedClassCDO);
+	}
+
+	return false;
+}
+
+TSharedRef<FTokenizedMessage> UCommonValidatorsStatics::CreateLinkedMessage(const FAssetData& InAssetData, const FText& Text,
+	EMessageSeverity::Type Severity)
+{
+	// Blank Message
+	TSharedRef<FTokenizedMessage> TokenizedMessage = FTokenizedMessage::Create(Severity,FText());
+
+	TokenizedMessage->AddToken(FAssetDataToken::Create(InAssetData));
+
+	if(!Text.IsEmpty())
+	{
+		TokenizedMessage->AddToken( FTextToken::Create(Text) );
+	}
+
+	return TokenizedMessage;
 }

--- a/Source/CommonValidators/CommonValidatorsStatics.h
+++ b/Source/CommonValidators/CommonValidatorsStatics.h
@@ -14,9 +14,20 @@ class COMMONVALIDATORS_API UCommonValidatorsStatics : public UBlueprintFunctionL
 	GENERATED_BODY()
 
 public:
+	UFUNCTION()
+	static void OpenBlueprint(UBlueprint* Blueprint);
+	
     UFUNCTION()
     static void OpenBlueprintAndFocusNode(UBlueprint* Blueprint, UEdGraph* Graph, UEdGraphNode* Node);
 
     UFUNCTION()
     static void DeleteNodeFromBlueprint(UBlueprint* Blueprint, UEdGraph* Graph, UEdGraphNode* Node);
+
+	UFUNCTION()
+	static bool IsObjectAChildOf(const UObject* const AnyAssetReference, const TSubclassOf<UObject> ObjectClass);
+
+	UFUNCTION()
+	static bool IsAssetAChildOf(const FAssetData& AnyAssetReference, const TSubclassOf<UObject> ObjectClass);
+	
+	static TSharedRef<FTokenizedMessage> CreateLinkedMessage(const FAssetData& InAssetData, const FText& Text, EMessageSeverity::Type Severity);
 };

--- a/Source/CommonValidators/CommonValidatorsStatics.h
+++ b/Source/CommonValidators/CommonValidatorsStatics.h
@@ -30,4 +30,6 @@ public:
 	static bool IsAssetAChildOf(const FAssetData& AnyAssetReference, const TSubclassOf<UObject> ObjectClass);
 	
 	static TSharedRef<FTokenizedMessage> CreateLinkedMessage(const FAssetData& InAssetData, const FText& Text, EMessageSeverity::Type Severity);
+
+	static FAssetIdentifier GetAssetIdentifierFromAssetData(const FAssetData& AssetData);
 };

--- a/Source/CommonValidators/EditorValidator_HeavyReference.cpp
+++ b/Source/CommonValidators/EditorValidator_HeavyReference.cpp
@@ -1,0 +1,266 @@
+// Copyright Notice
+// Author
+
+// This Header
+#include "EditorValidator_HeavyReference.h"
+
+// Unreal
+#include "AssetManagerEditor/Public/AssetManagerEditorModule.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Engine/AssetManager.h"
+#include "Engine/Blueprint.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Misc/DataValidation.h"
+
+// Project
+
+// Local
+#include "CommonValidatorsDeveloperSettings.h"
+#include "CommonValidatorsStatics.h"
+
+
+#define LOCTEXT_NAMESPACE "CommonValidators"
+
+namespace UE::Internal::HeavyReferenceValidatorHelpers
+{
+} // namespace UE::Internal::HeavyReferenceValidatorHelpers
+
+bool UEditorValidator_HeavyReference::CanValidateAsset_Implementation(
+	const FAssetData& InAssetData,
+	UObject* InObject,
+	FDataValidationContext& InContext) const
+{
+	if (!IsValid(InObject))
+	{
+		return false;
+	}
+
+	// Early out to prevent chewing CPU time when not enabled
+	if (!GetDefault<UCommonValidatorsDeveloperSettings>()->bEnableHeavyReferenceValidator)
+	{
+		return false;
+	}
+
+	UBlueprint* Blueprint = Cast<UBlueprint>(InObject);
+	if (!IsValid(Blueprint))
+	{
+		return false;
+	}
+
+	// Check if we want to run validation here
+	// Remove any BPs that inherit from the classes in class and child list
+	{
+		const TArray<TSubclassOf<UObject>>& IgnoreChildrenList = GetDefault<UCommonValidatorsDeveloperSettings>()->
+			HeavyValidatorClassAndChildIgnoreList;
+		for (const TSubclassOf<UObject>& IgnoredChild : IgnoreChildrenList)
+		{
+			if (UCommonValidatorsStatics::IsObjectAChildOf(InObject, IgnoredChild))
+			{
+				return false;
+			}
+		}
+	}
+
+	// Limit to BPs for now?
+	return true && InObject->IsA<UBlueprint>();
+}
+
+
+EDataValidationResult UEditorValidator_HeavyReference::ValidateLoadedAsset_Implementation(const FAssetData& InAssetData, UObject* InAsset,
+                                                                                          FDataValidationContext& Context)
+{
+	// Ignore non-BP types
+	UBlueprint* Blueprint = Cast<UBlueprint>(InAsset);
+	if (!IsValid(Blueprint))
+	{
+		return EDataValidationResult::NotValidated;
+	}
+
+	// Remove any BPs that inherit from the classes in class and child list
+	{
+		const TArray<TSubclassOf<UObject>>& IgnoreChildrenList = GetDefault<UCommonValidatorsDeveloperSettings>()->
+			HeavyValidatorClassAndChildIgnoreList;
+		for (const TSubclassOf<UObject>& IgnoredChild : IgnoreChildrenList)
+		{
+			if (UCommonValidatorsStatics::IsObjectAChildOf(InAsset, IgnoredChild))
+			{
+				return EDataValidationResult::NotValidated;
+			}
+		}
+	}
+	
+	const bool bShouldError = GetDefault<UCommonValidatorsDeveloperSettings>()->bErrorHeavyReference;
+
+	const FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<
+		FAssetRegistryModule>("AssetRegistry");
+	IAssetRegistry* const AssetReg = &AssetRegistryModule.Get();
+	IAssetManagerEditorModule* const EditorModule = &IAssetManagerEditorModule::Get();
+
+	FAssetIdentifier InAssetIdentifier;
+	{
+		FPrimaryAssetId PrimaryAssetId = IAssetManagerEditorModule::ExtractPrimaryAssetIdFromFakeAssetData(InAssetData);
+
+		if (PrimaryAssetId.IsValid())
+		{
+			InAssetIdentifier = PrimaryAssetId;
+		}
+		else
+		{
+			InAssetIdentifier = InAssetData.PackageName;
+		}
+	}
+
+	// Got assets. We want to sizemap these
+	TSet<FAssetIdentifier> VisitList;
+	TArray<FAssetIdentifier> FoundAssetList;
+	FoundAssetList.Add(InAssetIdentifier);
+	uint64 TotalSize = 0;
+
+	for (uint64 i = 0; i < FoundAssetList.Num(); i++)
+	{
+		const FAssetIdentifier& FoundAssetId = FoundAssetList[i];
+		if (VisitList.Contains(FoundAssetId))
+		{
+			// Cont
+			continue;
+		}
+
+		VisitList.Add(FoundAssetId);
+
+		// Size this asset first
+		FName AssetPackageName = FoundAssetId.IsPackage() ? FoundAssetId.PackageName : NAME_None;
+		FString AssetPackageNameString = (AssetPackageName != NAME_None) ? AssetPackageName.ToString() : FString();
+		FPrimaryAssetId AssetPrimaryId = FoundAssetId.GetPrimaryAssetId();
+		int32 ChunkId = UAssetManager::ExtractChunkIdFromPrimaryAssetId(AssetPrimaryId);
+
+		// Only support packages and primary assets
+		if (AssetPackageName == NAME_None && !AssetPrimaryId.IsValid())
+		{
+			UE_LOG(LogTemp, Display, TEXT("Asset not including in size: %s"), *FoundAssetId.PackageName.ToString())
+			continue;
+		}
+
+		// Don't bother showing code references
+		if (AssetPackageNameString.StartsWith(TEXT("/Script/")))
+		{
+			UE_LOG(LogTemp, Display, TEXT("Code Refs are defined as okie-dokie: %s"), *FoundAssetId.PackageName.ToString())
+			continue;
+		}
+
+		// Set some defaults for this node. These will be used if we can't actually locate the asset.
+		FAssetData ThisAssetData;
+		if (AssetPackageName != NAME_None)
+		{
+			ThisAssetData.AssetName = AssetPackageName;
+			ThisAssetData.AssetClassPath = FTopLevelAssetPath(TEXT("/None"), TEXT("MissingAsset"));
+
+			const FString AssetPathString = AssetPackageNameString + TEXT(".") + FPackageName::GetLongPackageAssetName(AssetPackageNameString);
+			FAssetData FoundData = AssetReg->GetAssetByObjectPath(FSoftObjectPath(AssetPathString));
+
+			if (FoundData.IsValid())
+			{
+				ThisAssetData = MoveTemp(FoundData);
+			}
+		}
+		else
+		{
+			ThisAssetData = IAssetManagerEditorModule::CreateFakeAssetDataFromPrimaryAssetId(AssetPrimaryId);
+		}
+		
+		// Gather Specific Ref Classes to ignore for the root asset
+		TArray<TSubclassOf<UObject>, TInlineAllocator<8>> IgnoredClassList;
+		for (auto& ClassToIgnoreEntry : GetDefault<UCommonValidatorsDeveloperSettings>()->HeavyValidatorClassSpecificClassIgnoreList)
+		{
+			// Does this apply to this asset?
+			// Allowed on the root (idx0) and if propagation is set.
+			if (i == 0 || ClassToIgnoreEntry.Value.AllowPropagationToChildren)
+			{
+				const TSubclassOf<UObject> IgnoredClass = ClassToIgnoreEntry.Key;
+
+				if (UCommonValidatorsStatics::IsObjectAChildOf(InAsset, IgnoredClass))
+				{
+					IgnoredClassList.Append(ClassToIgnoreEntry.Value.ClassList);
+				}
+			}
+		}
+
+		// Ignore if this asset is in the ignore list
+		bool bIsReferenceIgnored = false;
+		for (const TSubclassOf<UObject>& IgnoreClass : IgnoredClassList)
+		{
+			// Needs to resolve BP class..
+			if (UCommonValidatorsStatics::IsAssetAChildOf(ThisAssetData, IgnoreClass))
+			{
+				bIsReferenceIgnored = true;
+			}
+
+			//const UObject* GeneratedClassCDO = IsValid(AsBlueprint->GeneratedClass) ? AsBlueprint->GeneratedClass->GetDefaultObject() : nullptr;
+			//const null* const AsType = Cast<null>(GeneratedClassCDO);
+		}
+
+		// Go for asset sizing
+		if (ThisAssetData.IsValid() && !bIsReferenceIgnored)
+		{
+			FAssetManagerDependencyQuery DependencyQuery = FAssetManagerDependencyQuery::None();
+			DependencyQuery.Flags = UE::AssetRegistry::EDependencyQuery::Game;
+
+			if (AssetPackageName != NAME_None)
+			{
+				DependencyQuery.Categories = UE::AssetRegistry::EDependencyCategory::Package;
+				DependencyQuery.Flags |= UE::AssetRegistry::EDependencyQuery::Hard;
+			}
+			else
+			{
+				// ?
+				DependencyQuery.Categories = UE::AssetRegistry::EDependencyCategory::Manage;
+				DependencyQuery.Flags |= UE::AssetRegistry::EDependencyQuery::Direct;
+			}
+
+			// Ignore ourselves in this calc.
+			// We are not a reference: we are us.
+			if (AssetPackageName != NAME_None && i > 0)
+			{
+				int64 FoundSize = 0;
+				if (EditorModule->GetIntegerValueForCustomColumn(ThisAssetData, IAssetManagerEditorModule::ResourceSizeName, FoundSize))
+				{
+					TotalSize += FoundSize;
+				}
+				else
+				{
+					// ?
+					UE_LOG(LogTemp, Warning, TEXT("Cannot stat size for %s.%s"), *FoundAssetId.ToString(), *AssetPackageNameString);
+				}
+			}
+
+			// Find lowers
+			TArray<FAssetIdentifier> OutAssetData;
+			AssetReg->GetDependencies(FoundAssetId, OutAssetData, DependencyQuery.Categories, DependencyQuery.Flags);
+
+			// The TArray may have realloc'd and caused our pointer to invalidate at this point.
+			// FoundAssetId is now unsafe to use.
+			IAssetManagerEditorModule::Get().FilterAssetIdentifiersForCurrentRegistrySource(OutAssetData, DependencyQuery, true);
+
+			FoundAssetList.Append(OutAssetData);
+		}
+	}
+
+	if (TotalSize > GetDefault<UCommonValidatorsDeveloperSettings>()->MaximumAllowedReferenceSizeKiloBytes * 1024)
+	{
+		TSharedRef<FTokenizedMessage> ResultMessage = UCommonValidatorsStatics::CreateLinkedMessage(InAssetData,
+				FText::Format(
+					LOCTEXT("CommonValidators.HeavyRef.AssetWarning", "Heavy references in asset {0}! ({1})"),
+					FText::FromString(InAssetIdentifier.ToString()),
+					TotalSize
+					),
+				(bShouldError ? EMessageSeverity::Error : EMessageSeverity::PerformanceWarning)
+			);
+		
+		Context.AddMessage(ResultMessage);
+
+		return bShouldError ? EDataValidationResult::Invalid : EDataValidationResult::Valid;
+	}
+
+	return EDataValidationResult::Valid;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/CommonValidators/EditorValidator_HeavyReference.h
+++ b/Source/CommonValidators/EditorValidator_HeavyReference.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "EditorValidatorBase.h"
+
+#include "EditorValidator_HeavyReference.generated.h"
+
+/**
+ *
+ */
+UCLASS()
+class COMMONVALIDATORS_API UEditorValidator_HeavyReference : public UEditorValidatorBase
+{
+	GENERATED_BODY()
+	
+	virtual bool CanValidateAsset_Implementation(const FAssetData& InAssetData, UObject* InObject, FDataValidationContext& InContext) const override;
+	virtual EDataValidationResult ValidateLoadedAsset_Implementation(const FAssetData& InAssetData, UObject* InAsset, FDataValidationContext& Context) override;
+};

--- a/Source/CommonValidators/EditorValidator_HeavyReference.h
+++ b/Source/CommonValidators/EditorValidator_HeavyReference.h
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "CoreMinimal.h"
+// Unreal
 #include "EditorValidatorBase.h"
+#include "AssetRegistry/IAssetRegistry.h"
 
+// Local
+#include "CommonValidatorsDeveloperSettings.h"
+
+// Gen
 #include "EditorValidator_HeavyReference.generated.h"
 
 /**
@@ -15,4 +20,10 @@ class COMMONVALIDATORS_API UEditorValidator_HeavyReference : public UEditorValid
 	
 	virtual bool CanValidateAsset_Implementation(const FAssetData& InAssetData, UObject* InObject, FDataValidationContext& InContext) const override;
 	virtual EDataValidationResult ValidateLoadedAsset_Implementation(const FAssetData& InAssetData, UObject* InAsset, FDataValidationContext& Context) override;
+
+private:
+	bool IsAssetIncluded(const UCommonValidatorsDeveloperSettings* const DevSettings, const UObject* const InAsset, const FAssetData& ThisAssetData);
+	bool GetAssetData(const IAssetRegistry* const AssetRegistry, const FAssetIdentifier& FoundAssetId, FAssetData& OutAssetData);
+	FAssetManagerDependencyQuery SetupDependencyQuery(const FName& AssetName);
+	
 };


### PR DESCRIPTION
Adds a validator that checks the memory size of each asset that can be validated and warns or errors above a threshold to attempt to catch hard references that can cause longer than expected loads.
Optionally, expected large files can be removed and expected large dependencies of certain classes can be removed via the developer settings.

Probably some better defaults on this one as only UAnimBlueprint is excluded as that is almost always heavy.
UI widgets, for example, often get surfaced due to texture references, and these could be excluded.