### PR TITLE
A mixed bag of fixes and little improvements

### DIFF
--- a/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
+++ b/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
@@ -92,6 +92,10 @@ public:
 	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Blocking Load Validator", meta = (EditCondition = "bEnableBlockingLoadValidator == true"))
 	bool bErrorBlockingLoad = true;
 
+	//If true, we ignore nodes which are disabled for compilation
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Blocking Load Validator", DisplayName="Ignore disabled nodes", meta = (EditCondition = "bEnableBlockingLoadValidator == true"))
+	bool bBlockingLoadIgnoreDisabledNodes = true;
+
 	
 	/* Heavy Reference Validator */
 	// If true, we will validate for references above the set value in blueprints

--- a/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
+++ b/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
@@ -4,24 +4,6 @@
 #include "Templates/SubclassOf.h"
 #include "Animation/AnimBlueprint.h"
 #include "Engine/DeveloperSettings.h"
-#include "Kismet/BlueprintInstancedStructLibrary.h"
-#include "Kismet/BlueprintMapLibrary.h"
-#include "Kismet/BlueprintPathsLibrary.h"
-#include "Kismet/BlueprintPlatformLibrary.h"
-#include "Kismet/BlueprintSetLibrary.h"
-#include "Kismet/DataTableFunctionLibrary.h"
-#include "Kismet/GameplayStatics.h"
-#include "Kismet/KismetArrayLibrary.h"
-#include "Kismet/KismetGuidLibrary.h"
-#include "Kismet/KismetInputLibrary.h"
-#include "Kismet/KismetInternationalizationLibrary.h"
-#include "Kismet/KismetMaterialLibrary.h"
-#include "Kismet/KismetMathLibrary.h"
-#include "Kismet/KismetNodeHelperLibrary.h"
-#include "Kismet/KismetRenderingLibrary.h"
-#include "Kismet/KismetStringTableLibrary.h"
-#include "Kismet/KismetSystemLibrary.h"
-#include "Kismet/KismetTextLibrary.h"
 
 #include "CommonValidatorsDeveloperSettings.generated.h"
 
@@ -77,24 +59,24 @@ public:
 		{
 			// FCommonValidatorClassArray
 			{
-				UKismetMathLibrary::StaticClass(),
-				UKismetSystemLibrary::StaticClass(),
-				UKismetTextLibrary::StaticClass(),
-				UKismetRenderingLibrary::StaticClass(),
-				UKismetMaterialLibrary::StaticClass(),
-				UKismetArrayLibrary::StaticClass(),
-				UGameplayStatics::StaticClass(),
-				UKismetStringTableLibrary::StaticClass(),
-				UKismetInternationalizationLibrary::StaticClass(),
-				UKismetInputLibrary::StaticClass(),
-				UKismetGuidLibrary::StaticClass(),
-				UDataTableFunctionLibrary::StaticClass(),
-				UBlueprintSetLibrary::StaticClass(),
-				UBlueprintPlatformLibrary::StaticClass(),
-				UBlueprintPathsLibrary::StaticClass(),
-				UBlueprintMapLibrary::StaticClass(),
-				UBlueprintInstancedStructLibrary::StaticClass(),
-				UKismetNodeHelperLibrary::StaticClass()
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetMathLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetSystemLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetTextLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetRenderingLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetMaterialLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetArrayLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.GameplayStatics")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetStringTableLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetInternationalizationLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetInputLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetGuidLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.DataTableFunctionLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.BlueprintSetLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.BlueprintPlatformLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.BlueprintPathsLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.BlueprintMapLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.BlueprintInstancedStructLibrary")),
+				TSoftClassPtr<>(FSoftClassPath("/Script/Engine.KismetNodeHelperLibrary"))
 			},
 			true
 		}

--- a/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
+++ b/Source/CommonValidators/CommonValidatorsDeveloperSettings.h
@@ -4,6 +4,24 @@
 #include "Templates/SubclassOf.h"
 #include "Animation/AnimBlueprint.h"
 #include "Engine/DeveloperSettings.h"
+#include "Kismet/BlueprintInstancedStructLibrary.h"
+#include "Kismet/BlueprintMapLibrary.h"
+#include "Kismet/BlueprintPathsLibrary.h"
+#include "Kismet/BlueprintPlatformLibrary.h"
+#include "Kismet/BlueprintSetLibrary.h"
+#include "Kismet/DataTableFunctionLibrary.h"
+#include "Kismet/GameplayStatics.h"
+#include "Kismet/KismetArrayLibrary.h"
+#include "Kismet/KismetGuidLibrary.h"
+#include "Kismet/KismetInputLibrary.h"
+#include "Kismet/KismetInternationalizationLibrary.h"
+#include "Kismet/KismetMaterialLibrary.h"
+#include "Kismet/KismetMathLibrary.h"
+#include "Kismet/KismetNodeHelperLibrary.h"
+#include "Kismet/KismetRenderingLibrary.h"
+#include "Kismet/KismetStringTableLibrary.h"
+#include "Kismet/KismetSystemLibrary.h"
+#include "Kismet/KismetTextLibrary.h"
 
 #include "CommonValidatorsDeveloperSettings.generated.h"
 
@@ -13,11 +31,19 @@ struct FCommonValidatorClassArray
 	GENERATED_BODY()
 	
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Common Validators")
-	TArray<TSubclassOf<UObject>> ClassList;
+	TArray<TSoftClassPtr<UObject>> ClassList;
 
 	// Should this rule propagate to discovered children?
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Common Validators")
 	bool AllowPropagationToChildren = true;
+
+	bool MatchesClass(TSubclassOf<UObject> ClassToCheck) const
+	{
+		return ClassList.ContainsByPredicate([&](const TSoftClassPtr<UObject> &SoftClassPtr)
+		   {
+			   return AllowPropagationToChildren ? SoftClassPtr.IsValid() && ClassToCheck->IsChildOf(SoftClassPtr.Get()) : ClassToCheck.Get() == SoftClassPtr;
+		   });	
+	}
 };
 
 UCLASS(config = Editor, defaultconfig, meta = (DisplayName = "Common Validators"))
@@ -26,52 +52,89 @@ class COMMONVALIDATORS_API UCommonValidatorsDeveloperSettings : public UDevelope
 	GENERATED_BODY()
 
 public:
+	/* Empty Tick Node Validator */
 	// If true, we will validate for empty tick nodes.
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators")
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Empty Tick Node Validator")
 	bool bEnableEmptyTickNodeValidator = true;
 	
 	//If true, we throw an error, otherwise a warning!
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableEmptyTickNodeValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Empty Tick Node Validator", meta = (EditCondition = "bEnableEmptyTickNodeValidator == true"))
 	bool bErrorOnEmptyTickNodes = true;
+
 	
+	/* Pure Node Validator */
 	// if true, we will validate for pure nodes being executed multiple times
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators")
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Pure Node Validator")
 	bool bEnablePureNodeMultiExecValidator = true;
 	
 	//If true, we throw an error, otherwise a warning!
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnablePureNodeMultiExecValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Pure Node Validator", meta = (EditCondition = "bEnablePureNodeMultiExecValidator == true"))
 	bool bErrorOnPureNodeMultiExec = true;
+
+	// Methods/Nodes from classes in this list will be ignored by the pure node validator
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Pure Node Validator", meta = (EditCondition = "bEnablePureNodeMultiExecValidator == true"))
+	TArray<FCommonValidatorClassArray> PureNodeValidatorHarmlessClasses = {
+		{
+			// FCommonValidatorClassArray
+			{
+				UKismetMathLibrary::StaticClass(),
+				UKismetSystemLibrary::StaticClass(),
+				UKismetTextLibrary::StaticClass(),
+				UKismetRenderingLibrary::StaticClass(),
+				UKismetMaterialLibrary::StaticClass(),
+				UKismetArrayLibrary::StaticClass(),
+				UGameplayStatics::StaticClass(),
+				UKismetStringTableLibrary::StaticClass(),
+				UKismetInternationalizationLibrary::StaticClass(),
+				UKismetInputLibrary::StaticClass(),
+				UKismetGuidLibrary::StaticClass(),
+				UDataTableFunctionLibrary::StaticClass(),
+				UBlueprintSetLibrary::StaticClass(),
+				UBlueprintPlatformLibrary::StaticClass(),
+				UBlueprintPathsLibrary::StaticClass(),
+				UBlueprintMapLibrary::StaticClass(),
+				UBlueprintInstancedStructLibrary::StaticClass(),
+				UKismetNodeHelperLibrary::StaticClass()
+			},
+			true
+		}
+	};
+
 	
+	/* Blocking Load Validator */
 	// If true, we will validate for blocking loads in blueprints
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators")
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Blocking Load Validator")
 	bool bEnableBlockingLoadValidator = true;
 	
 	//If true, we throw an error, otherwise a warning!
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableBlockingLoadValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Blocking Load Validator", meta = (EditCondition = "bEnableBlockingLoadValidator == true"))
 	bool bErrorBlockingLoad = true;
 
+	
+	/* Heavy Reference Validator */
 	// If true, we will validate for references above the set value in blueprints
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators")
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Heavy Reference Validator")
 	bool bEnableHeavyReferenceValidator = true;
 
 	// If the total size on disk is above this, we consider the asset heavy
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Heavy Reference Validator", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
 	int MaximumAllowedReferenceSizeKiloBytes = 20480;
 
 	// Whether an inability to gather the size of a child asset is an warning
 	// This will prevent further context messages in most cases
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Heavy Reference Validator", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
 	bool bWarnOnUnsizableChildren = false;
 
 	//If true, we throw an error, otherwise a warning!
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Heavy Reference Validator", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
 	bool bErrorHeavyReference = false;
 
 	// Classes in this list, and their children, are ignored by heavy reference validator
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
-	TArray<TSubclassOf<UObject>> HeavyValidatorClassAndChildIgnoreList = {UAnimBlueprint::StaticClass()};
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Heavy Reference Validator", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	TArray<TSoftClassPtr<UObject>> HeavyValidatorClassAndChildIgnoreList = {UAnimBlueprint::StaticClass()};
 
 	// Classes in this list, and only classes in this list, are ignored by heavy reference validator
-	UPROPERTY(Config, EditAnywhere, Category="Common Validators", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
-	TMap<TSubclassOf<UObject>, FCommonValidatorClassArray> HeavyValidatorClassSpecificClassIgnoreList;
+	UPROPERTY(Config, EditAnywhere, Category="Common Validators|Heavy Reference Validator", meta = (EditCondition = "bEnableHeavyReferenceValidator == true"))
+	TMap<TSoftClassPtr<UObject>, FCommonValidatorClassArray> HeavyValidatorClassSpecificClassIgnoreList;
+
 };

--- a/Source/CommonValidators/CommonValidatorsStatics.cpp
+++ b/Source/CommonValidators/CommonValidatorsStatics.cpp
@@ -80,18 +80,10 @@ bool UCommonValidatorsStatics::IsObjectAChildOf(const UObject* const AnyAssetRef
 		return false;
 	}
 
-	// Blueprint assets derive from UBlueprint first, so IsA won't work directly
-	if (AnyAssetReference->IsA(UBlueprint::StaticClass()))
+	// Blueprint assets derive from UBlueprint first, so IsA won't work directly and the CDO can be used for the check 
+	if(const UBlueprint *Blueprint = Cast<UBlueprint>(AnyAssetReference))
 	{
-		// This asset may need converted to first native class unless ObjectClass is also a BP
-		const UBlueprint* const Blueprint = Cast<UBlueprint>(AnyAssetReference);
-		if (!IsValid(Blueprint))
-		{
-			return false;
-		}
-		
-		const UClass* const ParentClass = FBlueprintEditorUtils::FindFirstNativeClass(Blueprint->ParentClass);
-		if (ParentClass->IsChildOf(ObjectClass))
+		if(Blueprint->GeneratedClass && Blueprint->GeneratedClass->GetDefaultObject()->IsA(ObjectClass))
 		{
 			return true;
 		}

--- a/Source/CommonValidators/EditorValidator_BlockingLoad.cpp
+++ b/Source/CommonValidators/EditorValidator_BlockingLoad.cpp
@@ -29,32 +29,36 @@ EDataValidationResult UEditorValidator_BlockingLoad::ValidateLoadedAsset_Impleme
 	TArray<UEdGraph*> AllGraphs;
 	AllGraphs.Append(Blueprint->FunctionGraphs);
 	AllGraphs.Append(Blueprint->UbergraphPages);
+
+	const UCommonValidatorsDeveloperSettings *CommonValidatorSettings = GetDefault<UCommonValidatorsDeveloperSettings>();
+	const bool bShouldError = CommonValidatorSettings->bErrorBlockingLoad;
 	
     for (UEdGraph* Graph : AllGraphs)
 	{
 		for (UEdGraphNode* Node : Graph->Nodes)
 		{
-			if (IsBlockingLoad(Node))
-			{
-				bool bShouldError = GetDefault<UCommonValidatorsDeveloperSettings>()->bErrorBlockingLoad;
+			if (!IsBlockingLoad(Node))
+				continue;
 
-				// Create a tokenized message with an action to open the Blueprint and focus the node
-				TSharedRef<FTokenizedMessage> TokenizedMessage = FTokenizedMessage::Create((bShouldError ? EMessageSeverity::Error : EMessageSeverity::Warning), FText::FromString(TEXT("Blocking (synchronous) loading nodes found.")));
+			if (CommonValidatorSettings->bBlockingLoadIgnoreDisabledNodes && !Node->IsNodeEnabled())
+				continue;
 
-				TokenizedMessage->AddToken(FActionToken::Create(
-					FText::FromString(TEXT("Open Blueprint and Focus Node")),
-					FText::FromString(TEXT("Open Blueprint and Focus Node")),
-					FOnActionTokenExecuted::CreateLambda([Blueprint, Graph, Node]()
-						{
-							UCommonValidatorsStatics::OpenBlueprintAndFocusNode(Blueprint, Graph, Node);
-						}),
-					false
-				));
+			// Create a tokenized message with an action to open the Blueprint and focus the node
+			TSharedRef<FTokenizedMessage> TokenizedMessage = FTokenizedMessage::Create((bShouldError ? EMessageSeverity::Error : EMessageSeverity::Warning), FText::FromString(TEXT("Blocking (synchronous) loading nodes found.")));
 
-				Context.AddMessage(TokenizedMessage);
+			TokenizedMessage->AddToken(FActionToken::Create(
+				FText::FromString(TEXT("Open Blueprint and Focus Node")),
+				FText::FromString(TEXT("Open Blueprint and Focus Node")),
+				FOnActionTokenExecuted::CreateLambda([Blueprint, Graph, Node]()
+					{
+						UCommonValidatorsStatics::OpenBlueprintAndFocusNode(Blueprint, Graph, Node);
+					}),
+				false
+			));
 
-				DataValidationResult = bShouldError ? EDataValidationResult::Invalid : EDataValidationResult::Valid;
-			}
+			Context.AddMessage(TokenizedMessage);
+
+			DataValidationResult = bShouldError ? EDataValidationResult::Invalid : EDataValidationResult::Valid;			
 		}
 	}
 

--- a/Source/CommonValidators/EditorValidator_HeavyReference.cpp
+++ b/Source/CommonValidators/EditorValidator_HeavyReference.cpp
@@ -170,7 +170,7 @@ EDataValidationResult UEditorValidator_HeavyReference::ValidateLoadedAsset_Imple
 				FText::Format(
 					LOCTEXT("CommonValidators.HeavyRef.AssetWarning", "Heavy references in asset {0}! ({1})"),
 					FText::FromString(InAssetIdentifier.ToString()),
-					TotalSize
+					FText::AsMemory(TotalSize)
 					),
 				(DevSettings->bErrorHeavyReference ? EMessageSeverity::Error : EMessageSeverity::PerformanceWarning)
 			);

--- a/Source/CommonValidators/EditorValidator_HeavyReference.cpp
+++ b/Source/CommonValidators/EditorValidator_HeavyReference.cpp
@@ -47,11 +47,11 @@ bool UEditorValidator_HeavyReference::CanValidateAsset_Implementation(
 	// Check if we want to run validation here
 	// Remove any BPs that inherit from the classes in class and child list
 	{
-		const TArray<TSubclassOf<UObject>>& IgnoreChildrenList = GetDefault<UCommonValidatorsDeveloperSettings>()->
+		const TArray<TSoftClassPtr<UObject>>& IgnoreChildrenList = GetDefault<UCommonValidatorsDeveloperSettings>()->
 			HeavyValidatorClassAndChildIgnoreList;
-		for (const TSubclassOf<UObject>& IgnoredChild : IgnoreChildrenList)
+		for (const TSoftClassPtr<UObject>& IgnoredChild : IgnoreChildrenList)
 		{
-			if (UCommonValidatorsStatics::IsObjectAChildOf(InObject, IgnoredChild))
+			if (IgnoredChild.IsValid() && UCommonValidatorsStatics::IsObjectAChildOf(InObject, IgnoredChild.Get()))
 			{
 				return false;
 			}
@@ -80,10 +80,10 @@ EDataValidationResult UEditorValidator_HeavyReference::ValidateLoadedAsset_Imple
 
 	// Remove any BPs that inherit from the classes in class and child list
 	{
-		const TArray<TSubclassOf<UObject>>& IgnoreChildrenList = DevSettings->HeavyValidatorClassAndChildIgnoreList;
-		for (const TSubclassOf<UObject>& IgnoredChild : IgnoreChildrenList)
+		const TArray<TSoftClassPtr<UObject>>& IgnoreChildrenList = DevSettings->HeavyValidatorClassAndChildIgnoreList;
+		for (const TSoftClassPtr<UObject>& IgnoredChild : IgnoreChildrenList)
 		{
-			if (UCommonValidatorsStatics::IsObjectAChildOf(InAsset, IgnoredChild))
+			if (IgnoredChild.IsValid() && UCommonValidatorsStatics::IsObjectAChildOf(InAsset, IgnoredChild.Get()))
 			{
 				return EDataValidationResult::NotValidated;
 			}
@@ -187,17 +187,28 @@ bool UEditorValidator_HeavyReference::IsAssetIncluded(const UCommonValidatorsDev
 {
 	// Gather Specific Ref Classes to ignore for the root asset
 	TArray<TSubclassOf<UObject>, TInlineAllocator<8>> IgnoredClassList;
-	for (auto& ClassToIgnoreEntry : DevSettings->HeavyValidatorClassSpecificClassIgnoreList)
+	for (auto &ClassToIgnoreEntry : DevSettings->HeavyValidatorClassSpecificClassIgnoreList)
 	{
+		// we can skip unloaded classes
+		if(!ClassToIgnoreEntry.Key.IsValid())
+			continue;
+		
 		// Does this apply to this asset?
 		// Allowed on the root (idx0) and if propagation is set.
 		if (ClassToIgnoreEntry.Value.AllowPropagationToChildren)
 		{
-			const TSubclassOf<UObject> IgnoredClass = ClassToIgnoreEntry.Key;
+			const TSubclassOf<UObject> IgnoredClass = ClassToIgnoreEntry.Key.Get();
 
 			if (UCommonValidatorsStatics::IsObjectAChildOf(InAsset, IgnoredClass))
 			{
-				IgnoredClassList.Append(ClassToIgnoreEntry.Value.ClassList);
+				for(auto &SoftClassPtr : ClassToIgnoreEntry.Value.ClassList)
+				{
+					if(SoftClassPtr.IsValid())
+					{
+						IgnoredClassList.Add(SoftClassPtr.Get());
+					}
+				}
+				
 			}
 		}
 	}

--- a/Source/CommonValidators/EditorValidator_PureNode.cpp
+++ b/Source/CommonValidators/EditorValidator_PureNode.cpp
@@ -34,34 +34,15 @@ namespace UE::Internal::PureNodeValidatorHelpers
 		{
 			return false;
 		}
-		
-		const FString OwnerName = OwnerClass->GetName();
 
-		if (OwnerName.Contains(TEXT("KismetMathLibrary")) ||
-			OwnerName.Contains(TEXT("KismetSystemLibrary")) ||
-			OwnerName.Contains(TEXT("KismetTextLibrary")) ||
-			OwnerName.Contains(TEXT("KismetStringTableLibrary")) ||
-			OwnerName.Contains(TEXT("KismetRenderingLibrary")) ||
-			OwnerName.Contains(TEXT("KismetMaterialLibrary")) ||
-			OwnerName.Contains(TEXT("KismetInternationalizationLibrary")) ||
-			OwnerName.Contains(TEXT("KismetInputLibrary")) ||
-			OwnerName.Contains(TEXT("KismetGuidLibrary")) ||
-			OwnerName.Contains(TEXT("KismetArrayLibrary")) ||
-			OwnerName.Contains(TEXT("GameplayStatics")) ||
-			OwnerName.Contains(TEXT("DataTableFunctionLibrary")) ||
-			OwnerName.Contains(TEXT("BlueprintSetLibrary")) ||
-			OwnerName.Contains(TEXT("BlueprintPlatformLibrary")) ||
-			OwnerName.Contains(TEXT("BlueprintPathsLibrary")) ||
-			OwnerName.Contains(TEXT("BlueprintMapLibrary")) ||
-			OwnerName.Contains(TEXT("BlueprintInstancedStructLibrary")) ||
-			OwnerName.Contains(TEXT("KismetNodeHelperLibrary")))
+	    // check the user settings for classes that should be treated as harmless
+		if (GetDefault<UCommonValidatorsDeveloperSettings>()->PureNodeValidatorHarmlessClasses.ContainsByPredicate([&](const FCommonValidatorClassArray &CommonValidatorClassArray)
+		{
+		   return CommonValidatorClassArray.MatchesClass(OwnerClass);	    
+		}))
 		{
 			return true;
 		}
-
-		//TODO: Allow users to expand the list above? --KaosSpectrum
-		//Maybe find a better way (though i can't think of one...)
-		
 
 		return false;
 	}


### PR DESCRIPTION
Hi Ari, 
thanks for sharing those validators, made a few improvements, feel free to cherry pick what you merge.

key changes:

* replaced all TSubclassOf members in the developer settings with TSoftClassPtr<> as TSubclassOf<> acts like a hard ref, which can mess up module loading order when referencing classes from the project
* moved hardcoded "harmless" class list from pure node validator to developer settings
* BlockingLoadValidator added option to ignore nodes which are disabled (defaults to true)
* Statics: fixed how Objects are checked for parents, the old check did only work for native parent classes, now BPs are checked for their BP parents and their actual class parents